### PR TITLE
Check that probabilities are nonnegative

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -22,11 +22,13 @@ function obs_prob_consistency_check(pomdp::POMDP)
     for s in sspace
         for a in aspace
             obs = observation(pomdp, a, s)
-            p = 0.0
+            psum = 0.0
             for o in ospace
-                p += pdf(obs, o)
+                p = pdf(obs, o)
+                @assert p ≥ 0 "Probability is negative for state: ", s, " action: ", a, " observation: ", o
+                psum += p
             end
-            @assert isapprox(p, 1.0) "Observation probability does not sum to unity for state: ", s, " action: ", a
+            @assert isapprox(psum, 1.0) "Observation probability does not sum to unity for state: ", s, " action: ", a
         end
     end
 end
@@ -44,11 +46,13 @@ function trans_prob_consistency_check(pomdp::Union{MDP, POMDP})
     for s in sspace
         for a in aspace
             tran = transition(pomdp, s, a)
-            p = 0.0
+            psum = 0.0
             for sp in sspace
-                p += pdf(tran, sp)
+                p = pdf(tran, sp)
+                @assert p ≥ 0 "Probability is negative for state: ", s, " action: ", a, " next state: ", sp
+                psum += p
             end
-            @assert isapprox(p, 1.0) "Transition probability does not sum to unity for state: ", s, " action: ", a
+            @assert isapprox(psum, 1.0) "Transition probability does not sum to unity for state: ", s, " action: ", a
         end
     end
 end


### PR DESCRIPTION
This commit adds a check that the transition and observation probabilities are nonnegative.

I'm not super experienced with JuliaPOMDPs so I wasn't sure what test to add. By default, I'd just add tests involving `TabularPOMDP`s that are known to fail the conditions, because that's what I'm currently working with myself. But that would add a test dependency on `POMDPModels`. Let me know if you think that'd be a good idea.

Let me know if any further modifications would be helpful 🙂
