### PR TITLE
Using string interpolation in error messages

### DIFF
--- a/src/model.jl
+++ b/src/model.jl
@@ -22,11 +22,13 @@ function obs_prob_consistency_check(pomdp::POMDP)
     for s in sspace
         for a in aspace
             obs = observation(pomdp, a, s)
-            p = 0.0
+            psum = 0.0
             for o in ospace
-                p += pdf(obs, o)
+                p = pdf(obs, o)
+                @assert p ≥ 0 "Probability is negative for state: ", s, " action: ", a, " observation: ", o
+                psum += p
             end
-            @assert isapprox(p, 1.0) "Observation probability does not sum to unity for state: ", s, " action: ", a
+            @assert isapprox(psum, 1.0) "Observation probability does not sum to unity for state: ", s, " action: ", a
         end
     end
 end
@@ -44,11 +46,13 @@ function trans_prob_consistency_check(pomdp::Union{MDP, POMDP})
     for s in sspace
         for a in aspace
             tran = transition(pomdp, s, a)
-            p = 0.0
+            psum = 0.0
             for sp in sspace
-                p += pdf(tran, sp)
+                p = pdf(tran, sp)
+                @assert p ≥ 0 "Probability is negative for state: ", s, " action: ", a, " next state: ", sp
+                psum += p
             end
-            @assert isapprox(p, 1.0) "Transition probability does not sum to unity for state: ", s, " action: ", a
+            @assert isapprox(psum, 1.0) "Transition probability does not sum to unity for state: ", s, " action: ", a
         end
     end
 end

--- a/src/model.jl
+++ b/src/model.jl
@@ -25,10 +25,10 @@ function obs_prob_consistency_check(pomdp::POMDP)
             psum = 0.0
             for o in ospace
                 p = pdf(obs, o)
-                @assert p ≥ 0 "Probability is negative for state: ", s, " action: ", a, " observation: ", o
+                @assert p ≥ 0 "Probability is negative for state: $s, action: $a, observation: $o"
                 psum += p
             end
-            @assert isapprox(psum, 1.0) "Observation probability does not sum to unity for state: ", s, " action: ", a
+            @assert isapprox(psum, 1.0) "Observation probability does not sum to unity for state: $s, action: $a"
         end
     end
 end
@@ -49,10 +49,10 @@ function trans_prob_consistency_check(pomdp::Union{MDP, POMDP})
             psum = 0.0
             for sp in sspace
                 p = pdf(tran, sp)
-                @assert p ≥ 0 "Probability is negative for state: ", s, " action: ", a, " next state: ", sp
+                @assert p ≥ 0 "Probability is negative for state: $s, action: $a, next state: $sp"
                 psum += p
             end
-            @assert isapprox(psum, 1.0) "Transition probability does not sum to unity for state: ", s, " action: ", a
+            @assert isapprox(psum, 1.0) "Transition probability does not sum to unity for state: $s, action: $a"
         end
     end
 end


### PR DESCRIPTION
Currently I get error messages like this:
```
ERROR: AssertionError: ("Transition probability does not sum to unity for state: ", 1, " action: ", 1)
```

This commit changes them to
```
ERROR: AssertionError: Transition probability does not sum to unity for state: 1, action: 1
```

This PR sits on top of #5, so if you merge #5, it'll just be the second commit. I did it this way because #5 adds more error messages, and to try to keep the two PRs orthogonal-ish.

Let me know if there's a subtlety I'm missing! I've only tested it on simple TabularMDPs and TabularPOMDPs, since I don't know how to make more complicated ones fail consistency checks.